### PR TITLE
Fix: K8s Nginx Server Crashing Due to Port 80 Conflict

### DIFF
--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -1,4 +1,18 @@
 ---
+# Check port 80(HTTP) is closed, not used by any other service
+- name: Check port 80 is closed
+  ansible.builtin.wait_for:
+    host:  128.84.155.135
+    port: 80
+    state: stopped
+    delay: 0
+    timeout: 10
+  ignore_errors: true
+  register: port_result
+
+# - name: Display the result
+#   debug:
+#    var: port_result
 
 # prep Ubuntu to support RKE2-for-Aether
 

--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -2,15 +2,15 @@
 # Check port 80(HTTP) is closed, not used by any other service
 - name: Check port 80 is closed
   ansible.builtin.wait_for:
-    host:  128.84.155.135
     port: 80
     state: stopped
     delay: 0
-    timeout: 10
+    timeout: 10 #increase timeout for more hosts in inventory
+  when: inventory_hostname in groups['master_nodes']
   ignore_errors: true
   register: port_result
 
-# - name: Display the result
+# - name: Display the port result
 #   debug:
 #    var: port_result
 


### PR DESCRIPTION
Issue
The K8s Nginx server is experiencing crashes due to another application (Apache2) already using port 80.

Cause
The root cause of the issue is a port conflict, with Apache2 utilizing port 80.

Proposed Solution
To address this error, the following task has been added in the K8s playbook install yaml:

Task Name: Check Port 80 Closure

Description: Added a task to verify that port 80 is closed when running the the K8s playbook.