### PR TITLE
Fix issue copying binary

### DIFF
--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -89,6 +89,7 @@
     src: /var/lib/rancher/rke2/bin/kubectl
     dest: /usr/local/bin/kubectl
     mode: "a+x"
+    remote_src: true
   when: inventory_hostname in groups['master_nodes']
   become: true
 


### PR DESCRIPTION
This PR addresses an issue copying `kubectl` when the K8s cluster is deployed in a machine different than the one where aether-onramp is located.
With this PR. both scenarios are properly handled:
1. K8s cluster is deployed in the same machine where aether-onramp is
2. K8s cluster is deployed in a machine different than the one where aether-onramp is