### PR TITLE
Address issue by avoiding "writing" Kubeconfig file in worker nodes

### DIFF
--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -164,6 +164,7 @@
     path: "{{ ansible_env.HOME }}/.kube/config"
     regexp: 'https://127\.0\.0\.1:6443'
     replace: "https://{{ hostvars[groups['master_nodes'][0]]['ansible_default_ipv4']['address'] }}:6443"
+  when: inventory_hostname in groups['master_nodes']
 
 - name: change {{ ansible_env.HOME }}/.kube ownership
   shell: |


### PR DESCRIPTION
Kube config file only exists in master node. So, in multi-node K8s deployments, the Ansible script fails because it tries to replace some content in the kube config file, which does NOT exist. This PR fixes this issue