### PR TITLE
Use IP address from hosts file instead of using default node/host IP

### DIFF
--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -159,12 +159,15 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: Replace //127.0.0.1 with {{ hostvars[groups['master_nodes'][0]]['ansible_default_ipv4']['address'] }}
+- name: Replace 127.0.0.1 if needed
   replace:
     path: "{{ ansible_env.HOME }}/.kube/config"
     regexp: 'https://127\.0\.0\.1:6443'
-    replace: "https://{{ hostvars[groups['master_nodes'][0]]['ansible_default_ipv4']['address'] }}:6443"
-  when: inventory_hostname in groups['master_nodes']
+    replace: "https://{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}:6443"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] is defined
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] != '127.0.0.1'
 
 - name: change {{ ansible_env.HOME }}/.kube ownership
   shell: |


### PR DESCRIPTION
When copying the K8s config file into `$HOME/.kube/config`, Ansible replaces `127.0.01` with the host/node default IP address, which might be a surprise for users because they indicate in the `hosts.ini` file what IP address should be used for every node. This PR fixes this by using `ansible_host` from hosts.ini instead of using the node machine default IP,

Also, this PR includes a check to make this change (execute this task) only if the user set an IP different than `127.0.0.1` because if the user runs Onramp in a single host and wants to use `127.0.0.1` in the hosts.ini file, make no sense to replace "127.0.0.1" with "127.0.0.1"