### PR TITLE
Fix issue with K8s wait command

### DIFF
--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -93,11 +93,49 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: waiting for the master node(s) to get ready
-  shell: |
-    kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait nodes --for=condition=Ready --all --timeout=300s
-    kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait deployment -n kube-system --for=condition=available --all --timeout=300s
+- name: wait for the Kubernetes API to respond
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get --raw=/readyz
+  register: rke2_api_ready
+  retries: 60
+  delay: 5
+  until: rke2_api_ready.rc == 0
+  changed_when: false
   when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: wait for node objects to be registered
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes -o name
+  register: rke2_nodes
+  retries: 60
+  delay: 5
+  until: rke2_nodes.stdout | trim != ''
+  changed_when: false
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: wait for the master node(s) to get ready
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait nodes --for=condition=Ready --all --timeout=300s
+  changed_when: false
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: detect kube-system deployments
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get deployment -n kube-system -o name
+  register: kube_system_deployments
+  retries: 12
+  delay: 10
+  until: kube_system_deployments.stdout | trim != ''
+  failed_when: false
+  changed_when: false
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: wait for kube-system deployments to become available
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait deployment -n kube-system --for=condition=available --all --timeout=300s
+  changed_when: false
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - kube_system_deployments.stdout | trim != ''
   become: true
 
 - name: force systemd to reread configs

--- a/roles/rke2/tasks/install.yml
+++ b/roles/rke2/tasks/install.yml
@@ -103,12 +103,12 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: wait for node objects to be registered
-  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes -o name
-  register: rke2_nodes
+- name: wait for this master node object to be registered
+  shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get node "{{ inventory_hostname }}" -o name
+  register: rke2_current_node
   retries: 60
   delay: 5
-  until: rke2_nodes.stdout | trim != ''
+  until: rke2_current_node.rc == 0 and (rke2_current_node.stdout | trim) != ''
   changed_when: false
   when: inventory_hostname in groups['master_nodes']
   become: true
@@ -129,6 +129,13 @@
   changed_when: false
   when: inventory_hostname in groups['master_nodes']
   become: true
+
+- name: fail if kube-system deployments never appeared
+  fail:
+    msg: kube-system deployments did not appear before the retry window expired
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - kube_system_deployments.stdout | trim == ''
 
 - name: wait for kube-system deployments to become available
   shell: kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait deployment -n kube-system --for=condition=available --all --timeout=300s


### PR DESCRIPTION
When deploying a K8s through Onramp, the blueprint has consistently failed in the following task:
```yaml
- name: waiting for the master node(s) to get ready
  shell: |
    kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait nodes --for=condition=Ready --all --timeout=300s
    kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait deployment -n kube-system --for=condition=available --all --timeout=300s
  when: inventory_hostname in groups['master_nodes']
  become: true
```
With the following error
```
TASK [rke2 : waiting for the master node(s) to get ready] **************************************************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": "kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait nodes --for=condition=Ready --all --timeout=300s\nkubectl --kubeconfig /etc/rancher/rke2/rke2.yaml wait deployment -n kube-system --for=condition=available --all --timeout=300s\n", "delta": "0:00:00.150446", "end": "2026-04-01 10:56:17.506734", "msg": "non-zero return code", "rc": 1, "start": "2026-04-01 10:56:17.356288", "stderr": "error: no matching resources found\nerror: no matching resources found", "stderr_lines": ["error: no matching resources found", "error: no matching resources found"], "stdout": "", "stdout_lines": []}

PLAY RECAP *************************************************************************************************************
node1                      : ok=14   changed=8    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
When digging deeper into the issue and running some tests using different systems, the task is NOT failing due to the `timeout` for the wait condition, which is 5 mins (300s). Here are a couple examples:

```
Wednesday 01 April 2026  10:56:17 -0700 (0:00:00.436)       0:01:03.108 *******
===============================================================================
rke2 : start rke2-server on masters ---------------------------------------------------------------------------- 53.91s
rke2 : install rke2 on masters ---------------------------------------------------------------------------------- 2.43s
Gathering Facts ------------------------------------------------------------------------------------------------- 1.27s
rke2 : enable rke2-server on masters ---------------------------------------------------------------------------- 0.98s
rke2 : download rke2 -------------------------------------------------------------------------------------------- 0.80s
rke2 : copy master-config.yaml to /etc/rancher/rke2/config.yaml ------------------------------------------------- 0.80s
rke2 : copy kubectl --------------------------------------------------------------------------------------------- 0.62s
rke2 : waiting for the master node(s) to get ready -------------------------------------------------------------- 0.44s
rke2 : set fs.file-max to 2097152 ------------------------------------------------------------------------------- 0.37s
rke2 : remove /tmp/rke2 ----------------------------------------------------------------------------------------- 0.31s
rke2 : set fs.inotify.max_user_instances to 512 ----------------------------------------------------------------- 0.30s
rke2 : create /etc/rancher/rke2 --------------------------------------------------------------------------------- 0.30s
rke2 : set fs.inotify.max_user_watches to 524288 ---------------------------------------------------------------- 0.28s
rke2 : create /tmp/rke2 ----------------------------------------------------------------------------------------- 0.22s
rke2 : set_fact ------------------------------------------------------------------------------------------------- 0.04s
Playbook run took 0 days, 0 hours, 1 minutes, 3 seconds
make: *** [/home/aether/onramp/deps/k8s/Makefile:19: k8s-rke2-install] Error 2
```

```
Wednesday 01 April 2026  11:02:14 -0700 (0:00:00.399)       0:01:36.602 *******
===============================================================================
rke2 : start rke2-server on masters ---------------------------------------------------------------------------- 86.81s
rke2 : install rke2 on masters ---------------------------------------------------------------------------------- 2.50s
Gathering Facts ------------------------------------------------------------------------------------------------- 2.10s
rke2 : enable rke2-server on masters ---------------------------------------------------------------------------- 0.97s
rke2 : copy master-config.yaml to /etc/rancher/rke2/config.yaml ------------------------------------------------- 0.81s
rke2 : copy kubectl --------------------------------------------------------------------------------------------- 0.65s
rke2 : download rke2 -------------------------------------------------------------------------------------------- 0.49s
rke2 : waiting for the master node(s) to get ready -------------------------------------------------------------- 0.40s
rke2 : set fs.file-max to 2097152 ------------------------------------------------------------------------------- 0.38s
rke2 : remove /tmp/rke2 ----------------------------------------------------------------------------------------- 0.31s
rke2 : create /etc/rancher/rke2 --------------------------------------------------------------------------------- 0.31s
rke2 : set fs.inotify.max_user_watches to 524288 ---------------------------------------------------------------- 0.29s
rke2 : set fs.inotify.max_user_instances to 512 ----------------------------------------------------------------- 0.29s
rke2 : create /tmp/rke2 ----------------------------------------------------------------------------------------- 0.22s
rke2 : set_fact ------------------------------------------------------------------------------------------------- 0.02s
Playbook run took 0 days, 0 hours, 1 minutes, 36 seconds
make: *** [/home/aether/onramp/deps/k8s/Makefile:19: k8s-rke2-install] Error 2
```

As seen above, the `rke2 : waiting for the master node(s) to get ready` task fails after 44s and 40s, respectively, and the 300s (5 mins) timeout is not actually reached for this task to fail.

So, this PR splits this "single" task (2 shell commands) into multiple smaller sequential steps:
1. Wait for the K8s API to respond
2. Wait for node to be registered
3. Wait for master node to be ready (1st command that was executed in the task before this PR)
4. Check "default" (kube-system) deployment
5. Then, wait for `kube-system` deployment to be ready (2nd command that was executed in the task before this PR)